### PR TITLE
rebuild when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "babel-core": "^6.2.1",
     "babel-preset-es2015": "^6.1.18",
     "babel-register": "^6.2.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "rimraf": "^2.5.0"
   },
   "scripts": {
+    "clean": "rimraf lib",
+    "prebuild": "npm run clean",
     "build": "babel src -d lib",
+    "prepublish": "npm run build",
     "test": "mocha --compilers js:babel-register"
   },
   "keywords": [


### PR DESCRIPTION
This looks pretty neat! However it looks like the [published](https://www.npmjs.com/package/babel-plugin-handlebars-inline-precompile) `2.0.1` contains the Babel 5 version. This PR ensures a new build is created when publishing the package. The `lib` directory is erased to ensure no old files are left over.
