### PR TITLE
use the output name from addImport

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,16 +38,14 @@ export default function({ Plugin, types: t }) {
           throw this.errorWithNode(node, `Only \`import hbs from '${IMPORT_NAME}'\` is supported. You used: \`${usedImportStatement}\``);
         }
 
-        let name = scope.generateUidIdentifier('Handlebars').name;
+        const { name } = file.addImport('handlebars/runtime', 'default', scope.generateUid('Handlebars'));
+        path.remove();
 
         // Store the import name to lookup references elsewhere.
         file[IMPORT_PROP] = {
           input: first.local.name,
           output: name
         };
-
-        file.addImport('handlebars/runtime', 'default', name);
-        path.remove();
       },
 
       /**

--- a/test/fixtures/call-expression/expected.js
+++ b/test/fixtures/call-expression/expected.js
@@ -1,6 +1,6 @@
 import _Handlebars2 from 'handlebars/runtime';
 
-_Handlebars.template({
+_Handlebars2.template({
   "compiler": [7, ">= 4.0.0"],
   "main": function (container, depth0, helpers, partials, data) {
     return "Hello World!";

--- a/test/fixtures/tagged-template-expression/expected.js
+++ b/test/fixtures/tagged-template-expression/expected.js
@@ -1,6 +1,6 @@
 import _Handlebars2 from 'handlebars/runtime';
 
-_Handlebars.template({
+_Handlebars2.template({
   "compiler": [7, ">= 4.0.0"],
   "main": function (container, depth0, helpers, partials, data) {
     return "Hello World!";


### PR DESCRIPTION
The name argument to `addImport()` seemed to be ignored. It's unnecessary anyway, as long as the returned name is used.

The problem seems evident in the tests, it used to output `import _Handlebars2` but referenced `_Handlebars`.
