### PR TITLE
support local handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "handlebars": "^4.0.5"
+    "handlebars": "^4.0.5",
+    "resolve-cwd": "^1.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,9 @@
-import Handlebars from 'handlebars';
+import resolveCwd from 'resolve-cwd'
+
+// Use local handlebars (if installed as a peer) rather than the version that
+// came with this plugin. Allows a newer handlebars to be used without needing
+// to upgrade this package.
+const Handlebars = require(resolveCwd('handlebars') || 'handlebars')
 
 export default function({ Plugin, types: t }) {
   const IMPORT_NAME = 'handlebars-inline-precompile';


### PR DESCRIPTION
Use local handlebars (if installed as a peer) rather than the version that came with this plugin. Allows a newer handlebars to be used without needing to upgrade this package (as long as `Handlebars.precompile()` has a compatible interface).
