### PR TITLE
prefer 'files' over .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-node_modules
-*.log
-src

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "thejameskyle/babel-plugin-handlebars-inline-precompile",
   "license": "MIT",
   "main": "lib/index.js",
+  "files": ["lib"],
   "devDependencies": {
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",


### PR DESCRIPTION
Explicitly include _only_ the `lib` directory in the published package. Compared to the `.npmignore` file this now excludes the `.npmignore` and `.babelrc` files, as well as the tests. The tests require the `src` modules and dev dependencies so they wouldn't have worked anyway. The other files are unnecessary when publishing.

Before:

```
$ npm pack
babel-plugin-handlebars-inline-precompile-2.0.1.tgz
$ tar -ztvf babel-plugin-handlebars-inline-precompile-2.0.1.tgz
-rw-r--r--  0 501    20        591  8 Jan 15:47 package/package.json
-rw-r--r--  0 501    20         23  7 Jan 17:27 package/.npmignore
-rw-r--r--  0 501    20        728  7 Jan 17:27 package/README.md
-rw-r--r--  0 501    20         45  7 Jan 17:27 package/.babelrc
-rw-r--r--  0 501    20       3679  8 Jan 11:30 package/lib/index.js
-rw-r--r--  0 501    20        750  7 Jan 17:27 package/test/index.js
-rw-r--r--  0 501    20         70  7 Jan 17:27 package/test/fixtures/call-expression/actual.js
-rw-r--r--  0 501    20        222  8 Jan 11:25 package/test/fixtures/call-expression/expected.js
-rw-r--r--  0 501    20         34  7 Jan 17:27 package/test/fixtures/call-expression/.babelrc
-rw-r--r--  0 501    20         68  7 Jan 17:27 package/test/fixtures/tagged-template-expression/actual.js
-rw-r--r--  0 501    20        222  8 Jan 11:25 package/test/fixtures/tagged-template-expression/expected.js
-rw-r--r--  0 501    20         34  7 Jan 17:27 package/test/fixtures/tagged-template-expression/.babelrc
```

After:

```
$ tar -ztvf babel-plugin-handlebars-inline-precompile-2.0.1.tgz
-rw-r--r--  0 501    20        611  8 Jan 15:48 package/package.json
-rw-r--r--  0 501    20        728  7 Jan 17:27 package/README.md
-rw-r--r--  0 501    20       3679  8 Jan 11:30 package/lib/index.js
```
