### PR TITLE
remove unused Plugin reference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Handlebars from 'handlebars';
 
-export default function({ Plugin, types: t }) {
+export default function({ types: t }) {
   const IMPORT_NAME = 'handlebars-inline-precompile';
   const IMPORT_PROP = '_handlebarsImportSpecifier';
 


### PR DESCRIPTION
Just noticed this. Probably left over from the Babel 5 code?
