### PR TITLE
ignore tests and other dev files when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
+.babelrc
+.npmignore
 node_modules
 *.log
 src
+test


### PR DESCRIPTION
The tests don't run without the `src` files, `.babelrc` and `.npmignore` are not needed in the published package.

Achieves the same as https://github.com/thejameskyle/babel-plugin-handlebars-inline-precompile/pull/6.
