### PR TITLE
Fix plugin errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 *.log
 lib
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-register": "^6.2.0",
     "mocha": "^2.2.5",
+    "nyc": "^5.3.0",
     "rimraf": "^2.5.0"
   },
   "scripts": {
+    "coverage": "nyc npm test",
     "clean": "rimraf lib",
     "prebuild": "npm run clean",
     "build": "babel src -d lib",

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,8 @@ export default function({ types: t }) {
 
         // Throw an error if using anything other than the default import.
         if (!t.isImportDefaultSpecifier(first)) {
-          let usedImportStatement = file.code.slice(node.start, node.end);
-          throw this.errorWithNode(node, `Only \`import hbs from '${IMPORT_NAME}'\` is supported. You used: \`${usedImportStatement}\``);
+          let usedImportStatement = file.file.code.slice(node.start, node.end);
+          throw path.buildCodeFrameError(`Only \`import hbs from '${IMPORT_NAME}'\` is supported. You used: \`${usedImportStatement}\``);
         }
 
         const { name } = file.addImport('handlebars/runtime', 'default', scope.generateUid('Handlebars'));
@@ -65,14 +65,14 @@ export default function({ types: t }) {
           return;
         }
 
-        let template = node.arguments[0].value;
+        let template = node.arguments.length > 0 && node.arguments[0].value;
 
         // `hbs` should be called as `hbs('template')`.
         if (
           node.arguments.length !== 1 ||
           typeof template !== 'string'
         ) {
-          throw this.errorWithNode(node, `${node.callee.name} should be invoked with a single argument: the template string`);
+          throw path.buildCodeFrameError(`${node.callee.name} should be invoked with a single argument: the template string`);
         }
 
         compile(path, template, file[IMPORT_PROP].output);
@@ -92,7 +92,7 @@ export default function({ types: t }) {
 
         // hbs`${template}` is not supported.
         if (node.quasi.expressions.length) {
-          throw this.errorWithNode(node, 'placeholders inside a tagged template string are not supported');
+          throw path.buildCodeFrameError('placeholders inside a tagged template string are not supported');
         }
 
         let template = node.quasi.quasis.map(quasi => quasi.value.cooked).join('');

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,20 @@ function trim(str) {
   return str.replace(/^\s+|\s+$/, "");
 }
 
+function attempt (code) {
+  return () => babel.transform(code, {
+    babelrc: false,
+    filename: "index.js",
+    sourceRoot: __dirname,
+    plugins: [plugin]
+  }).code;
+}
+
+function check (msg) {
+  const preface = "index.js: ";
+  return err => err instanceof SyntaxError && err.message.slice(0, preface.length) === preface && err.message.slice(preface.length) === msg;
+}
+
 describe("precompiles inline templates", () => {
   const fixturesDir = path.join(__dirname, "fixtures");
 
@@ -21,5 +35,45 @@ describe("precompiles inline templates", () => {
 
       assert.equal(trim(actual), trim(expected));
     });
+  });
+});
+
+describe("importing anything other than the default", () => {
+  it("throws a SyntaxError", () => {
+    assert.throws(
+      attempt("import { foo } from 'handlebars-inline-precompile'"),
+      check(`Only \`import hbs from 'handlebars-inline-precompile'\` is supported. You used: \`import { foo } from 'handlebars-inline-precompile'\``));
+  });
+});
+
+describe("`hbs` is called with 0 arguments", () => {
+  it("throws a SyntaxError", () => {
+    assert.throws(
+      attempt("import hbs from 'handlebars-inline-precompile'; hbs()"),
+      check("hbs should be invoked with a single argument: the template string"));
+  });
+});
+
+describe("`hbs` is called with a non-string argument", () => {
+  it("throws a SyntaxError", () => {
+    assert.throws(
+      attempt("import hbs from 'handlebars-inline-precompile'; hbs(42)"),
+      check("hbs should be invoked with a single argument: the template string"));
+  });
+});
+
+describe("`hbs` is called with more than 1 argument", () => {
+  it("throws a SyntaxError", () => {
+    assert.throws(
+      attempt("import hbs from 'handlebars-inline-precompile'; hbs('foo', 'bar')"),
+      check("hbs should be invoked with a single argument: the template string"));
+  });
+});
+
+describe("`hbs` is used as a tagged template expression, with a template string containing placeholders", () => {
+  it("throws a SyntaxError", () => {
+    assert.throws(
+      attempt("import hbs from 'handlebars-inline-precompile'; hbs`${6 * 7 === 42}`"),
+      check("placeholders inside a tagged template string are not supported"));
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -8,11 +8,11 @@ function trim(str) {
   return str.replace(/^\s+|\s+$/, "");
 }
 
-describe("turn jsx into incremental-dom", () => {
+describe("precompiles inline templates", () => {
   const fixturesDir = path.join(__dirname, "fixtures");
 
   fs.readdirSync(fixturesDir).map((caseName) => {
-    it(`should ${caseName.split("-").join(" ")}`, () => {
+    it(`works for ${caseName.split("-").join(" ")}`, () => {
       const fixtureDir = path.join(fixturesDir, caseName);
       const actual     = babel.transformFileSync(
         path.join(fixtureDir, "actual.js")

--- a/test/index.js
+++ b/test/index.js
@@ -77,3 +77,9 @@ describe("`hbs` is used as a tagged template expression, with a template string 
       check("placeholders inside a tagged template string are not supported"));
   });
 });
+
+describe("other tagged template expressions occur", () => {
+  it("ignores them", () => {
+    assert.doesNotThrow(attempt("function foo () {}; foo`bar`"))
+  })
+});


### PR DESCRIPTION
Fixes #9.

I threw in a code coverage tool as well. With the new tests commented out:

```
-----------|----------|----------|----------|----------|----------------|
File       |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-----------|----------|----------|----------|----------|----------------|
 src/      |    82.76 |    77.27 |      100 |    80.77 |                |
  index.js |    82.76 |    77.27 |      100 |    80.77 | 42,43,75,90,95 |
-----------|----------|----------|----------|----------|----------------|
All files  |    82.76 |    77.27 |      100 |    80.77 |                |
-----------|----------|----------|----------|----------|----------------|
```

Final result:

```
-----------|----------|----------|----------|----------|----------------|
File       |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-----------|----------|----------|----------|----------|----------------|
 src/      |      100 |    95.45 |      100 |      100 |                |
  index.js |      100 |    95.45 |      100 |      100 |                |
-----------|----------|----------|----------|----------|----------------|
All files  |      100 |    95.45 |      100 |      100 |                |
-----------|----------|----------|----------|----------|----------------|
```

The tests don't cover [`|| 'handlebars'` bit](https://github.com/thejameskyle/babel-plugin-handlebars-inline-precompile/blob/7b27186d49925a5f437b852ef66bc38b0084c9b7/src/index.js#L6) since `resolveCwd('handlebars')` already resolves it. I guess that's OK.
